### PR TITLE
CI version upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,10 @@ on:
     tags-ignore: [ v* ]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: npm ci # Install dependencies.
       - run: npm run ci # Execute CI scripts.
       - run: git diff --exit-code # Fail if CI scripts make any source changes.
@@ -22,7 +21,7 @@ jobs:
         os: [ ubuntu-latest, macOS-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: npm ci # Install dependencies.
       - run: npm run build # Build javascript.
       - run: npm run package # Build action package.
@@ -36,7 +35,7 @@ jobs:
     needs: [ build, test ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: configure git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     types: [ created ]
 
 jobs:
-
   test:
     strategy:
       fail-fast: false
@@ -13,7 +12,7 @@ jobs:
         os: [ ubuntu-latest, macOS-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: npm ci # Install dependencies.
       - run: npm run build # Build javascript.
       - run: npm run package # Build action package.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021 Jean Michel Rouly
+Copyright (c) 2022 Jean Michel Rouly
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ branding:
   icon: 'code'
   color: 'gray-dark'
 runs:
-  using: node12
+  using: node16
   main: dist/index.js

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "format-check": "prettier --check **/*.ts",
     "lint": "eslint src/**/*.ts",
     "package": "ncc build --source-map --license licenses.txt",
-    "release": "./bin/release.sh",
     "test": "jest",
     "ci": "npm run clean && npm run build && npm run format && npm run lint && npm test"
   },


### PR DESCRIPTION
Upgrades the version of `actions/checkout` used during CI as well as the version of node (12 to 16).