### PR TITLE
Deprecated installer script

### DIFF
--- a/src/scalafmt.ts
+++ b/src/scalafmt.ts
@@ -38,8 +38,7 @@ async function setup(): Promise<void> {
 
 async function install(version: string): Promise<void> {
   core.startGroup(`Install scalafmt-native:${version}`)
-  const installerUrl =
-    `https://raw.githubusercontent.com/scalameta/scalafmt/refs/tags/v${defaultVersion}/bin/install-scalafmt-native.sh`
+  const installerUrl = `https://raw.githubusercontent.com/scalameta/scalafmt/refs/tags/v${defaultVersion}/bin/install-scalafmt-native.sh`
   const cmd = `curl -sL ${installerUrl} | bash -sv -- ${version} ${scalafmtPath} 2>&1`
   const {stdout} = await exec(cmd)
   core.info(stdout)

--- a/src/scalafmt.ts
+++ b/src/scalafmt.ts
@@ -39,7 +39,7 @@ async function setup(): Promise<void> {
 async function install(version: string): Promise<void> {
   core.startGroup(`Install scalafmt-native:${version}`)
   const installerUrl =
-    'https://raw.githubusercontent.com/scalameta/scalafmt/master/bin/install-scalafmt-native.sh'
+    `https://raw.githubusercontent.com/scalameta/scalafmt/refs/tags/v${version}/bin/install-scalafmt-native.sh`
   const cmd = `curl -sL ${installerUrl} | bash -sv -- ${version} ${scalafmtPath} 2>&1`
   const {stdout} = await exec(cmd)
   core.info(stdout)

--- a/src/scalafmt.ts
+++ b/src/scalafmt.ts
@@ -39,7 +39,7 @@ async function setup(): Promise<void> {
 async function install(version: string): Promise<void> {
   core.startGroup(`Install scalafmt-native:${version}`)
   const installerUrl =
-    `https://raw.githubusercontent.com/scalameta/scalafmt/refs/tags/v${version}/bin/install-scalafmt-native.sh`
+    `https://raw.githubusercontent.com/scalameta/scalafmt/refs/tags/v${defaultVersion}/bin/install-scalafmt-native.sh`
   const cmd = `curl -sL ${installerUrl} | bash -sv -- ${version} ${scalafmtPath} 2>&1`
   const {stdout} = await exec(cmd)
   core.info(stdout)


### PR DESCRIPTION
Per https://github.com/jrouly/scalafmt-native-action/issues/381 it looks like the installer script this action uses has been deleted from `master`.

In lieu of a longer term fix, pinning the installer script to a LKG version.